### PR TITLE
Implement questionnaire logic

### DIFF
--- a/app/src/main/java/com/postcare/app/QuestionnaireFragment.kt
+++ b/app/src/main/java/com/postcare/app/QuestionnaireFragment.kt
@@ -2,11 +2,16 @@ package com.postcare.app.ui
 
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
 import com.postcare.app.R
 import com.google.android.material.button.MaterialButton
 
 class QuestionnaireFragment : Fragment(R.layout.fragment_questionnaire) {
+
+    private val viewModel: QuestionnaireViewModel by viewModels()
 
     private lateinit var buttonYes: MaterialButton
     private lateinit var buttonNo: MaterialButton
@@ -22,26 +27,38 @@ class QuestionnaireFragment : Fragment(R.layout.fragment_questionnaire) {
         buttonNo = view.findViewById(R.id.button_no)
         buttonNext = view.findViewById(R.id.button_next)
 
+        // Restaure la réponse sauvegardée, le cas échéant
+        viewModel.answer.value?.let {
+            userAnswer = it
+            if (it == "OUI") {
+                highlightSelection(buttonYes, buttonNo)
+            } else if (it == "NON") {
+                highlightSelection(buttonNo, buttonYes)
+            }
+        }
+
         // Gestion des clics OUI
         buttonYes.setOnClickListener {
             userAnswer = "OUI"
+            viewModel.setAnswer("OUI")
             highlightSelection(buttonYes, buttonNo)
         }
 
         // Gestion des clics NON
         buttonNo.setOnClickListener {
             userAnswer = "NON"
+            viewModel.setAnswer("NON")
             highlightSelection(buttonNo, buttonYes)
         }
 
         // Bouton "Suivant"
         buttonNext.setOnClickListener {
-            if (userAnswer != null) {
-                // TODO : Traiter la réponse ou naviguer
-                // findNavController().navigate(R.id.action_questionnaire_to_nextFragment)
+            val answer = viewModel.answer.value
+            if (answer != null) {
+                viewModel.saveAnswer()
+                findNavController().popBackStack()
             } else {
-                // Afficher un message à l'utilisateur s'il n'a rien sélectionné
-                // (optionnel) Toast.makeText(requireContext(), "Veuillez sélectionner une réponse", Toast.LENGTH_SHORT).show()
+                Toast.makeText(requireContext(), "Veuillez sélectionner une réponse", Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/java/com/postcare/app/ui/QuestionnaireViewModel.kt
+++ b/app/src/main/java/com/postcare/app/ui/QuestionnaireViewModel.kt
@@ -1,0 +1,29 @@
+package com.postcare.app.ui
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.preference.PreferenceManager
+
+class QuestionnaireViewModel(application: Application) : AndroidViewModel(application) {
+
+    companion object {
+        private const val PREF_KEY = "QUESTION_ANSWER"
+    }
+
+    private val prefs = PreferenceManager.getDefaultSharedPreferences(application)
+
+    private val _answer = MutableLiveData<String?>().apply {
+        value = prefs.getString(PREF_KEY, null)
+    }
+    val answer: LiveData<String?> = _answer
+
+    fun setAnswer(value: String) {
+        _answer.value = value
+    }
+
+    fun saveAnswer() {
+        _answer.value?.let { prefs.edit().putString(PREF_KEY, it).apply() }
+    }
+}


### PR DESCRIPTION
## Summary
- add `QuestionnaireViewModel` to store answers in SharedPreferences
- persist previous selection and navigate when user responds

## Testing
- `./gradlew test` *(fails: unable to download gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68615d9a49008321a8209e10689c4b12