### PR TITLE
Enable patient item clicks

### DIFF
--- a/app/src/main/java/com/postcare/app/PatientAdapter.kt
+++ b/app/src/main/java/com/postcare/app/PatientAdapter.kt
@@ -28,6 +28,9 @@ class PatientAdapter(
         holder.tvName.text = patient.name
         holder.tvOperation.text = patient.operationDetails
         holder.tvStatus.text = patient.status
+        holder.itemView.setOnClickListener {
+            onItemClick(patient)
+        }
     }
 
     override fun getItemCount(): Int = patients.size

--- a/app/src/main/res/layout/item_patient.xml
+++ b/app/src/main/res/layout/item_patient.xml
@@ -5,7 +5,8 @@
     android:padding="12dp"
     android:background="#F5F5F5"
     android:layout_marginBottom="12dp"
-    android:elevation="2dp">
+    android:elevation="2dp"
+    android:clickable="true">
 
     <LinearLayout
         android:layout_width="0dp"


### PR DESCRIPTION
## Summary
- enable click events in `PatientAdapter`
- mark patient items clickable in layout

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6862fc3a7d1c8321bc3148cc22e0487c