### PR TITLE
Add image prediction screen with TFLite

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,4 +66,6 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation("androidx.compose.ui:ui-tooling-preview:1.8.3")
     implementation("androidx.compose.runtime:runtime-livedata:1.8.3")
+    implementation(libs.androidx.activity.compose)
+    implementation(libs.tensorflow.lite)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
         <activity android:name=".HomePageMedecin" />
         <activity android:name=".HomePagePatient" />
         <activity android:name=".DetailPatientActivity" />
+        <activity android:name=".ImagePredictionActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/postcare/app/HomePagePatient.kt
+++ b/app/src/main/java/com/postcare/app/HomePagePatient.kt
@@ -3,6 +3,7 @@ package com.postcare.app
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -19,8 +20,13 @@ class HomePagePatient : AppCompatActivity() {
         // Views
         val navView = findViewById<BottomNavigationView>(R.id.bottom_navigation)
         val header = findViewById<View>(R.id.header)
+        val predictButton = findViewById<Button>(R.id.btn_predict)
         navView.setBackgroundColor(ContextCompat.getColor(this, R.color.postcare_green))
         header.setBackgroundColor(ContextCompat.getColor(this, R.color.postcare_green))
+
+        predictButton.setOnClickListener {
+            startActivity(Intent(this, ImagePredictionActivity::class.java))
+        }
 
 
         navView.setOnItemSelectedListener { item ->

--- a/app/src/main/java/com/postcare/app/ImageClassifier.kt
+++ b/app/src/main/java/com/postcare/app/ImageClassifier.kt
@@ -1,0 +1,45 @@
+package com.postcare.app
+
+import android.content.Context
+import android.graphics.Bitmap
+import org.tensorflow.lite.Interpreter
+import java.io.FileInputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.channels.FileChannel
+
+class ImageClassifier(private val context: Context) {
+    private val interpreter: Interpreter by lazy { loadModel() }
+
+    private fun loadModel(): Interpreter {
+        val assetFileDescriptor = context.assets.openFd("model.tflite")
+        val fileInputStream = FileInputStream(assetFileDescriptor.fileDescriptor)
+        val fileChannel = fileInputStream.channel
+        val startOffset = assetFileDescriptor.startOffset
+        val declaredLength = assetFileDescriptor.declaredLength
+        val modelBuffer = fileChannel.map(FileChannel.MapMode.READ_ONLY, startOffset, declaredLength)
+        return Interpreter(modelBuffer)
+    }
+
+    fun classify(bitmap: Bitmap): FloatArray {
+        val inputSize = 224
+        val resizedBitmap = Bitmap.createScaledBitmap(bitmap, inputSize, inputSize, true)
+        val byteBuffer = ByteBuffer.allocateDirect(4 * inputSize * inputSize * 3)
+        byteBuffer.order(ByteOrder.nativeOrder())
+        val intValues = IntArray(inputSize * inputSize)
+        resizedBitmap.getPixels(intValues, 0, inputSize, 0, 0, inputSize, inputSize)
+        var pixel = 0
+        for (i in 0 until inputSize) {
+            for (j in 0 until inputSize) {
+                val value = intValues[pixel++]
+                byteBuffer.putFloat(((value shr 16 and 0xFF) / 255.0f))
+                byteBuffer.putFloat(((value shr 8 and 0xFF) / 255.0f))
+                byteBuffer.putFloat(((value and 0xFF) / 255.0f))
+            }
+        }
+
+        val output = Array(1) { FloatArray(1) }
+        interpreter.run(byteBuffer, output)
+        return output[0]
+    }
+}

--- a/app/src/main/java/com/postcare/app/ImagePredictionActivity.kt
+++ b/app/src/main/java/com/postcare/app/ImagePredictionActivity.kt
@@ -1,0 +1,79 @@
+package com.postcare.app
+
+import android.app.Activity
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.dp
+
+class ImagePredictionActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            PredictionScreen()
+        }
+    }
+}
+
+@Composable
+fun PredictionScreen() {
+    val context = LocalContext.current
+    val classifier = remember { ImageClassifier(context) }
+    var selectedImageUri by remember { mutableStateOf<Uri?>(null) }
+    var result by remember { mutableStateOf("") }
+
+    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+        selectedImageUri = uri
+        uri?.let {
+            context.contentResolver.openInputStream(it)?.use { stream ->
+                val bitmap = BitmapFactory.decodeStream(stream)
+                val outputs = classifier.classify(bitmap)
+                result = outputs.joinToString(prefix = "Result: ")
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = { Header({ (context as? Activity)?.finish() }) },
+        bottomBar = { BottomNavBar(0) {} }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            selectedImageUri?.let { uri ->
+                context.contentResolver.openInputStream(uri)?.use { stream ->
+                    val bitmap = BitmapFactory.decodeStream(stream)
+                    Image(bitmap.asImageBitmap(), contentDescription = null, modifier = Modifier.size(200.dp))
+                }
+            }
+
+            Button(
+                onClick = { launcher.launch("image/*") },
+                colors = ButtonDefaults.buttonColors(containerColor = colorResource(id = R.color.postcare_blue))
+            ) {
+                Text("Choisir une image", color = androidx.compose.ui.graphics.Color.White)
+            }
+
+            if (result.isNotEmpty()) {
+                Text(result)
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/homepage_patient.xml
+++ b/app/src/main/res/layout/homepage_patient.xml
@@ -184,6 +184,16 @@
             android:text="Douleur : 5/10" />
     </LinearLayout>
 
+    <Button
+        android:id="@+id/btn_predict"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Analyse image"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@id/historique_section"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <!-- Bottom navigation -->
     <include layout="@layout/layout_bottom_navigation"/>
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ navigationFragmentKtx = "2.9.0"
 navigationUiKtx = "2.9.0"
 uiToolingPreviewAndroid = "1.8.3"
 preference = "1.2.1"
+tensorflowLite = "2.14.0"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -40,6 +41,7 @@ androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navi
 androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigationUiKtx" }
 androidx-ui-tooling-preview-android = { group = "androidx.compose.ui", name = "ui-tooling-preview-android", version.ref = "uiToolingPreviewAndroid" }
 androidx-preference-ktx = { group = "androidx.preference", name = "preference-ktx", version.ref = "preference" }
+tensorflow-lite = { group = "org.tensorflow", name = "tensorflow-lite", version.ref = "tensorflowLite" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add tensorflow-lite dependency
- create `ImageClassifier` helper
- create `ImagePredictionActivity` with Compose UI to pick an image and run the model
- expose the activity from `HomePagePatient`
- add button in patient homepage layout
- register the new activity in the manifest
- fix unresolved Compose references by adding the activity-compose dependency

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68655176eed88321839d8bcddf7bcf5a

## Summary by Sourcery

Integrate TensorFlow Lite–powered image classification into the patient app by adding a dedicated Compose-based prediction screen, loading a TFLite model via a new helper, and exposing it from the patient homepage.

New Features:
- Add ImagePredictionActivity with Compose UI to select an image and display classification results
- Implement ImageClassifier helper to load a TensorFlow Lite model and perform inference on bitmaps
- Add a button in the patient homepage to navigate to the image prediction screen

Enhancements:
- Register ImagePredictionActivity in AndroidManifest

Build:
- Add TensorFlow Lite and androidx.activity.compose dependencies to Gradle build configuration

Chores:
- Update libs.versions.toml to include TensorFlow Lite version