### PR TITLE
Fix missing compose activity dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(libs.androidx.navigation.ui.ktx)
     implementation(libs.androidx.preference.ktx)
     implementation(libs.gson)
+    implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.ui.tooling.preview.android)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)


### PR DESCRIPTION
## Summary
- include `androidx.activity:activity-compose` in the app module to resolve `setContent` and `rememberLauncherForActivityResult` references

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686555d4c9d083218da9568c8fedb0de

## Summary by Sourcery

Build:
- Add androidx.activity:activity-compose dependency to the app module build configuration.