### PR TITLE
Fix questionnaire navigation with new activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
         <activity android:name=".HomePagePatient" />
         <activity android:name=".DetailPatientActivity" />
         <activity android:name=".ImagePredictionActivity" />
+        <activity android:name=".QuestionnaireActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/postcare/app/PreparationFragment.kt
+++ b/app/src/main/java/com/postcare/app/PreparationFragment.kt
@@ -6,8 +6,7 @@ import android.view.View
 import android.widget.RadioButton
 import android.widget.TextView
 import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.findNavController
-import com.postcare.app.ui.QuestionnaireFragment
+import com.postcare.app.QuestionnaireActivity
 
 class PreparationFragment : Fragment(R.layout.fragment_preparation) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -16,7 +15,8 @@ class PreparationFragment : Fragment(R.layout.fragment_preparation) {
         // Clique vers l'écran du questionnaire
         val link = view.findViewById<TextView>(R.id.go_to_questionnaire)
         link.setOnClickListener {
-            findNavController().navigate(R.id.fragment_questionnaire)
+            val intent = Intent(requireContext(), QuestionnaireActivity::class.java)
+            startActivity(intent)
         }
 
         // Références aux boutons ronds cochables (RadioButtons)

--- a/app/src/main/java/com/postcare/app/QuestionnaireActivity.kt
+++ b/app/src/main/java/com/postcare/app/QuestionnaireActivity.kt
@@ -1,0 +1,12 @@
+package com.postcare.app
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class QuestionnaireActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.fragment_questionnaire)
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `QuestionnaireActivity` to host the questionnaire layout
- launch the new activity from `PreparationFragment`
- register the activity in the manifest

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6865564f06188321ac413e24daf07b66

## Summary by Sourcery

Introduce a dedicated QuestionnaireActivity for hosting the questionnaire layout, update PreparationFragment to launch it directly instead of using the navigation component, and register the new activity in the AndroidManifest.

New Features:
- Add QuestionnaireActivity to display the questionnaire layout
- Update PreparationFragment to start QuestionnaireActivity via an explicit intent instead of NavController

Build:
- Register QuestionnaireActivity in AndroidManifest.xml