### PR TITLE
Fix Compose import for ImagePredictionActivity

### DIFF
--- a/app/src/main/java/com/postcare/app/ImagePredictionActivity.kt
+++ b/app/src/main/java/com/postcare/app/ImagePredictionActivity.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*


### PR DESCRIPTION
## Summary
- add missing `setContent` import in `ImagePredictionActivity`

## Testing
- `./gradlew tasks --all` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68655a0744f48321a0c88b731fdcefb5