### PR TITLE
Enable direct image selection

### DIFF
--- a/app/src/main/java/com/postcare/app/HomePagePatient.kt
+++ b/app/src/main/java/com/postcare/app/HomePagePatient.kt
@@ -1,6 +1,9 @@
 package com.postcare.app
 
 import android.content.Intent
+import android.net.Uri
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.result.ActivityResultLauncher
 import android.os.Bundle
 import android.view.View
 import android.widget.Button
@@ -9,9 +12,20 @@ import androidx.core.content.ContextCompat
 import com.google.android.material.bottomnavigation.BottomNavigationView
 
 class HomePagePatient : AppCompatActivity() {
+
+    private lateinit var pickImageLauncher: ActivityResultLauncher<String>
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.homepage_patient)
+
+        pickImageLauncher = registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+            uri?.let {
+                val intent = Intent(this, ImagePredictionActivity::class.java)
+                intent.putExtra("imageUri", it)
+                startActivity(intent)
+            }
+        }
 
         // Récupère le rôle
         val role = intent.getStringExtra("USER_TYPE")
@@ -26,7 +40,7 @@ class HomePagePatient : AppCompatActivity() {
 
         val predictButton = findViewById<Button>(R.id.btn_predict)
         predictButton.setOnClickListener {
-            startActivity(Intent(this, ImagePredictionActivity::class.java))
+            pickImageLauncher.launch("image/*")
         }
 
         navView.setOnItemSelectedListener { item ->


### PR DESCRIPTION
## Summary
- let HomePagePatient pick an image directly and open ImagePredictionActivity with it
- make ImagePredictionActivity handle an initial image for prediction

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686563e8d6188321a886f9c51d966478

## Summary by Sourcery

Enable direct image selection from the home page and prepopulate the prediction activity with the chosen image to perform classification on launch.

New Features:
- Allow HomePagePatient to select an image and launch ImagePredictionActivity with its URI
- Enable ImagePredictionActivity to accept an initial image URI and trigger immediate classification