### PR TITLE
Fix image prediction screen crash

### DIFF
--- a/app/src/main/java/com/postcare/app/ImagePredictionActivity.kt
+++ b/app/src/main/java/com/postcare/app/ImagePredictionActivity.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.unit.dp
+import android.widget.Toast
 
 class ImagePredictionActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -38,10 +39,15 @@ fun PredictionScreen(initialUri: Uri? = null) {
 
     LaunchedEffect(initialUri) {
         initialUri?.let { uri ->
-            context.contentResolver.openInputStream(uri)?.use { stream ->
-                val bitmap = BitmapFactory.decodeStream(stream)
-                val outputs = classifier.classify(bitmap)
-                result = outputs.joinToString(prefix = "Result: ")
+            try {
+                context.contentResolver.openInputStream(uri)?.use { stream ->
+                    val bitmap = BitmapFactory.decodeStream(stream)
+                    val outputs = classifier.classify(bitmap)
+                    result = outputs.joinToString(prefix = "Result: ")
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                Toast.makeText(context, "Erreur lors de l'analyse de l'image", Toast.LENGTH_LONG).show()
             }
         }
     }
@@ -49,10 +55,15 @@ fun PredictionScreen(initialUri: Uri? = null) {
     val launcher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
         selectedImageUri = uri
         uri?.let {
-            context.contentResolver.openInputStream(it)?.use { stream ->
-                val bitmap = BitmapFactory.decodeStream(stream)
-                val outputs = classifier.classify(bitmap)
-                result = outputs.joinToString(prefix = "Result: ")
+            try {
+                context.contentResolver.openInputStream(it)?.use { stream ->
+                    val bitmap = BitmapFactory.decodeStream(stream)
+                    val outputs = classifier.classify(bitmap)
+                    result = outputs.joinToString(prefix = "Result: ")
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                Toast.makeText(context, "Erreur lors de l'analyse de l'image", Toast.LENGTH_LONG).show()
             }
         }
     }

--- a/app/src/main/res/layout/homepage_patient.xml
+++ b/app/src/main/res/layout/homepage_patient.xml
@@ -192,7 +192,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>ù
+        app:layout_constraintEnd_toEndOf="parent"/>
 
     <!-- Bottom navigation -->
     <include layout="@layout/layout_bottom_navigation"/>


### PR DESCRIPTION
## Summary
- handle errors when classifying chosen images
- remove invalid character in homepage_patient layout

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68668282a6f48321bb392fb6d884304b

## Summary by Sourcery

Fix crash in image prediction flow by adding exception handling around image decoding and classification, display a user-facing toast on errors, and correct a stray character in the patient homepage layout XML.

Bug Fixes:
- Prevent app crash by wrapping image classification calls in try-catch blocks
- Remove stray invalid character in homepage_patient.xml layout

Enhancements:
- Show a toast message when image analysis fails