### PR TITLE
Fix crash on patient navigation

### DIFF
--- a/app/src/main/res/layout/fragment_preparation.xml
+++ b/app/src/main/res/layout/fragment_preparation.xml
@@ -11,6 +11,7 @@
 
     <!-- HEADER -->
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/header"
         android:layout_width="match_parent"
         android:layout_height="56dp"
         android:background="@color/postcare_green">


### PR DESCRIPTION
## Summary
- add missing `header` ID in `fragment_preparation.xml`

## Testing
- `./gradlew test` *(fails: unable to download Gradle wrapper due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686686b872cc83218147055fd72b34e8

## Summary by Sourcery

Bug Fixes:
- Add android:id="@+id/header" to the header ConstraintLayout to resolve patient navigation crash.