### PR TITLE
Update image analysis display

### DIFF
--- a/app/src/main/java/com/postcare/app/HomePagePatient.kt
+++ b/app/src/main/java/com/postcare/app/HomePagePatient.kt
@@ -7,6 +7,9 @@ import androidx.activity.result.ActivityResultLauncher
 import android.os.Bundle
 import android.view.View
 import android.widget.Button
+import android.widget.ImageView
+import android.widget.TextView
+import android.graphics.BitmapFactory
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -14,10 +17,13 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 class HomePagePatient : AppCompatActivity() {
 
     private lateinit var pickImageLauncher: ActivityResultLauncher<String>
+    private lateinit var classifier: ImageClassifier
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.homepage_patient)
+
+        classifier = ImageClassifier(this)
 
         // Récupère le rôle
         val role = intent.getStringExtra("USER_TYPE")
@@ -26,15 +32,28 @@ class HomePagePatient : AppCompatActivity() {
         // Views
         val navView = findViewById<BottomNavigationView>(R.id.bottom_navigation)
         val header = findViewById<View>(R.id.header)
+        val imageView = findViewById<ImageView>(R.id.iv_selected_image)
+        val resultView = findViewById<TextView>(R.id.tv_prediction_result)
 
         navView.setBackgroundColor(ContextCompat.getColor(this, R.color.postcare_green))
         header.setBackgroundColor(ContextCompat.getColor(this, R.color.postcare_green))
 
         pickImageLauncher = registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
             uri?.let {
-                val intent = Intent(this, ImagePredictionActivity::class.java)
-                intent.putExtra("imageUri", it)
-                startActivity(intent)
+                imageView.setImageURI(it)
+                imageView.visibility = View.VISIBLE
+                val result = try {
+                    contentResolver.openInputStream(it)?.use { stream ->
+                        val bitmap = BitmapFactory.decodeStream(stream)
+                        val outputs = classifier.classify(bitmap)
+                        outputs.joinToString(prefix = "Result: ")
+                    } ?: "Analyse impossible"
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                    "Erreur lors de l'analyse"
+                }
+                resultView.text = result
+                resultView.visibility = View.VISIBLE
             }
         }
         val predictButton = findViewById<Button>(R.id.btn_predict)

--- a/app/src/main/res/layout/homepage_patient.xml
+++ b/app/src/main/res/layout/homepage_patient.xml
@@ -194,6 +194,27 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
 
+    <ImageView
+        android:id="@+id/iv_selected_image"
+        android:layout_width="200dp"
+        android:layout_height="200dp"
+        android:visibility="gone"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@id/btn_predict"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <TextView
+        android:id="@+id/tv_prediction_result"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:layout_marginTop="8dp"
+        android:textColor="@android:color/black"
+        app:layout_constraintTop_toBottomOf="@id/iv_selected_image"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
     <!-- Bottom navigation -->
     <include layout="@layout/layout_bottom_navigation"/>
 


### PR DESCRIPTION
## Summary
- show analyzed image and result in HomePagePatient
- reuse the existing navigation bar layout on this page

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686687fca2908321b257845ea24e0803