### PR TITLE
Add PillBoxActivity with UI layout

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
         <activity android:name=".DetailPatientActivity" />
         <activity android:name=".ImagePredictionActivity" />
         <activity android:name=".QuestionnaireActivity" />
+        <activity android:name=".PillBoxActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/postcare/app/PillBoxActivity.kt
+++ b/app/src/main/java/com/postcare/app/PillBoxActivity.kt
@@ -1,0 +1,38 @@
+package com.postcare.app
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import com.google.android.material.bottomnavigation.BottomNavigationView
+
+class PillBoxActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_pillbox)
+
+        val navView = findViewById<BottomNavigationView>(R.id.bottom_navigation)
+        val header = findViewById<View>(R.id.header)
+
+        navView.setBackgroundColor(ContextCompat.getColor(this, R.color.postcare_green))
+        header.setBackgroundColor(ContextCompat.getColor(this, R.color.postcare_green))
+
+        navView.selectedItemId = R.id.nav_profile
+
+        findViewById<View>(R.id.back_arrow).setOnClickListener { finish() }
+
+        navView.setOnItemSelectedListener { item ->
+            when (item.itemId) {
+                R.id.nav_home -> {
+                    startActivity(Intent(this, HomePagePatient::class.java))
+                    true
+                }
+                R.id.nav_profile -> {
+                    true
+                }
+                else -> false
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/border_green.xml
+++ b/app/src/main/res/drawable/border_green.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@android:color/white" />
+    <stroke android:width="1dp" android:color="@color/postcare_green" />
+    <corners android:radius="8dp" />
+</shape>

--- a/app/src/main/res/layout/activity_pillbox.xml
+++ b/app/src/main/res/layout/activity_pillbox.xml
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <!-- Header -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/header"
+        android:layout_width="0dp"
+        android:layout_height="64dp"
+        android:background="@color/postcare_green"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <ImageView
+            android:id="@+id/back_arrow"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@drawable/ic_arrow_back"
+            android:layout_marginStart="16dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+        <ImageView
+            android:id="@+id/logo"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:src="@drawable/ic_logo"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- Title -->
+    <TextView
+        android:id="@+id/pillbox_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Pilulier"
+        android:textColor="@color/postcare_green"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintTop_toBottomOf="@id/header"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="12dp"/>
+
+    <!-- Morning Section -->
+    <LinearLayout
+        android:id="@+id/section_matin"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginTop="16dp"
+        android:orientation="vertical"
+        android:background="@drawable/border_green"
+        android:padding="8dp"
+        app:layout_constraintTop_toBottomOf="@id/pillbox_title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Matin"
+            android:textStyle="bold"/>
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/postcare_green"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="8dp"/>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+            <RadioButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:buttonTint="@color/postcare_green"
+                android:focusable="false"
+                android:focusableInTouchMode="false"/>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="Paracétamol | 125 mg"
+                android:textColor="@color/dark_green"
+                android:textSize="16sp" />
+        </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginTop="4dp">
+            <RadioButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="false"
+                android:buttonTint="@color/postcare_green"
+                android:focusable="false"
+                android:focusableInTouchMode="false"/>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="Ibuprofène | 200 mg"
+                android:textColor="@color/dark_green"
+                android:textSize="16sp" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <!-- Noon Section -->
+    <LinearLayout
+        android:id="@+id/section_midi"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginTop="8dp"
+        android:orientation="vertical"
+        android:background="@drawable/border_green"
+        android:padding="8dp"
+        app:layout_constraintTop_toBottomOf="@id/section_matin"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Midi"
+            android:textStyle="bold"/>
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/postcare_green"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="8dp"/>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+            <RadioButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:buttonTint="@color/postcare_green"
+                android:focusable="false"
+                android:focusableInTouchMode="false"/>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="Paracétamol | 125 mg"
+                android:textColor="@color/dark_green"
+                android:textSize="16sp" />
+        </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginTop="4dp">
+            <RadioButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="false"
+                android:buttonTint="@color/postcare_green"
+                android:focusable="false"
+                android:focusableInTouchMode="false"/>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="Ibuprofène | 200 mg"
+                android:textColor="@color/dark_green"
+                android:textSize="16sp" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <!-- Evening Section -->
+    <LinearLayout
+        android:id="@+id/section_soir"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="16dp"
+        android:orientation="vertical"
+        android:background="@drawable/border_green"
+        android:padding="8dp"
+        app:layout_constraintTop_toBottomOf="@id/section_midi"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/bottom_navigation">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Soir"
+            android:textStyle="bold"/>
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/postcare_green"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="8dp"/>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+            <RadioButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:buttonTint="@color/postcare_green"
+                android:focusable="false"
+                android:focusableInTouchMode="false"/>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="Paracétamol | 125 mg"
+                android:textColor="@color/dark_green"
+                android:textSize="16sp" />
+        </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginTop="4dp">
+            <RadioButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="false"
+                android:buttonTint="@color/postcare_green"
+                android:focusable="false"
+                android:focusableInTouchMode="false"/>
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="Ibuprofène | 200 mg"
+                android:textColor="@color/dark_green"
+                android:textSize="16sp" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <!-- Bottom navigation -->
+    <include
+        android:id="@+id/bottom_navigation"
+        layout="@layout/layout_bottom_navigation" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,5 +9,6 @@
     <color name="white">#FFFFFFFF</color>
     <color name="postcare_blue">#008BF9</color>
     <color name="postcare_green">#00B565</color>
+    <color name="dark_green">#009944</color>
     <color name="red_alert">#F44336</color>
 </resources>


### PR DESCRIPTION
## Summary
- create `PillBoxActivity` for the new pillbox interface
- design `activity_pillbox.xml` with header, medication sections and bottom navigation
- add drawable `border_green.xml` and color `dark_green`
- register new activity in manifest

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6866b094e80883218455401b47e69924

## Summary by Sourcery

Add a new PillBoxActivity featuring a structured UI for morning, noon, and evening medications with header and bottom navigation.

New Features:
- Introduce PillBoxActivity with layout including header, medication sections (morning/noon/evening), and bottom navigation
- Implement back arrow handling and bottom navigation item selection in PillBoxActivity

Enhancements:
- Add dark_green color and border_green drawable for consistent pillbox styling

Chores:
- Register PillBoxActivity in AndroidManifest.xml